### PR TITLE
fix missing request model to resolve paging properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### IDE
 .idea/
+.run/
 .vscode/
 
 ## linters/formatters

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,10 +3,16 @@
 [Unreleased](https://github.com/crim-ca/stac-app/tree/master)
 ------------------------------------------------------------------------------------------------------------------
 
+# Changed
+
+- Update to latest available versions `stac-fastapi.api==5.2.0`, `stac-fastapi.pgstac==5.0.2` and `uvicorn==0.34.2`.
+  This mostly includes security fixes, minor performance improvements, and many additional STAC-API extension features
+  that are not yet enabled, but planned in a following release. 
+
 # Fixed
 
-- Fix `next` paging link in `/collections/{collectionID}/items` that was not correctly resolving the `token` parameter,
-  leading to an endless loop over the first paging items.
+- Fix `rel=next` paging link in `/collections/{collectionID}/items` that was not correctly resolving the `token`
+  parameter, leading to an endless loop over the first paging items.
 
 [1.0.1](https://github.com/crim-ca/stac-app/tree/1.0.1)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,10 @@
 [Unreleased](https://github.com/crim-ca/stac-app/tree/master)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+# Fixed
+
+- Fix `next` paging link in `/collections/{collectionID}/items` that was not correctly resolving the `token` parameter,
+  leading to an endless loop over the first paging items.
 
 [1.0.1](https://github.com/crim-ca/stac-app/tree/1.0.1)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,8 @@
 # Fixed
 
 - Fix `rel=next` paging link in `/collections/{collectionID}/items` that was not correctly resolving the `token`
-  parameter, leading to an endless loop over the first paging items.
+  parameter, leading to an endless loop over the first paging items
+  (fixes [#26](https://github.com/crim-ca/stac-app/issues/26)).
 
 [1.0.1](https://github.com/crim-ca/stac-app/tree/1.0.1)
 ------------------------------------------------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-stac-fastapi.api==3.0.3 
-stac-fastapi.pgstac==3.0.0 
-uvicorn==0.32.0
+stac-fastapi.api==5.2.0
+stac-fastapi.pgstac==5.0.2
+uvicorn==0.34.2

--- a/src/stac_app.py
+++ b/src/stac_app.py
@@ -4,14 +4,20 @@
 import logging
 import os
 import time
-from typing import Optional
+from typing import Optional, Type, cast
 
 import asyncpg
 from buildpg import render
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import ORJSONResponse
 from stac_fastapi.api.app import StacApi
-from stac_fastapi.api.models import create_get_request_model, create_post_request_model
+from stac_fastapi.api.models import (
+    ItemCollectionUri,
+    create_request_model,
+    create_get_request_model,
+    create_post_request_model
+)
+from stac_fastapi.types.search import APIRequest
 from stac_fastapi.extensions.core import (
     FieldsExtension,
     FilterExtension,
@@ -34,6 +40,15 @@ logger = logging.getLogger("uvicorn.error")
 settings = Settings()
 settings.openapi_url = os.environ.get("OPENAPI_URL", "/api")
 settings.docs_url = os.environ.get("DOCS_URL", "/api.html")
+
+items_get_request_model = cast(
+    Type[APIRequest],
+    create_request_model(
+        "ItemCollectionURI",
+        base_model=ItemCollectionUri,
+        mixins=[TokenPaginationExtension().GET],
+    )
+)
 
 extensions = [
     TransactionExtension(
@@ -61,6 +76,7 @@ api = StacApi(
     client=CoreCrudClient(post_request_model=post_request_model),
     search_get_request_model=create_get_request_model(extensions),
     search_post_request_model=post_request_model,
+    items_get_request_model=items_get_request_model,
     response_class=ORJSONResponse,
     title=(os.getenv("STAC_FASTAPI_TITLE") or "Data Analytics for Canadian Climate Services STAC API"),
     description=(

--- a/src/stac_app.py
+++ b/src/stac_app.py
@@ -73,7 +73,7 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 api = StacApi(
     settings=settings,
     extensions=extensions,
-    client=CoreCrudClient(post_request_model=post_request_model),
+    client=CoreCrudClient(pgstac_search_model=post_request_model),
     search_get_request_model=create_get_request_model(extensions),
     search_post_request_model=post_request_model,
     items_get_request_model=items_get_request_model,


### PR DESCRIPTION
## Description

Resolves the `/collections/{collectionID}/items?limit=X` with returned `links` with `rel=next` to page to the following batch of items. 

- fix https://github.com/crim-ca/stac-app/issues/26
- update dependencies


Currently, `limit` and paging links are not functional under `/collections` directly. It should be possible, but the STAC-FastAPI implementation uses a pre-check of `CollectionSearchExtension` (see https://github.com/stac-utils/stac-fastapi-pgstac/blob/4ce90757f9d130b76ce8ed3791e0735a8128563c/stac_fastapi/pgstac/core.py#L75-L100), to make them effective.

This extension can be imported with updated python dependencies, but the underlying SQL `collection_search` function requires a more recent `pgstac` docker image. However, that upgrade (pgstac 0.6 to 7.x, 8.x, 9.x) requires many PG 13→15→17 migrations, so it will be done in a follow-up version to keep this fix minimal.

## To Do

- [ ] bump `1.1.0` after merge
- [ ] update tag/versions under https://github.com/bird-house/birdhouse-deploy/blob/master/birdhouse/components/stac/default.env
