### PR TITLE
fix `stac-fastapi>=6` compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,13 @@
 [Unreleased](https://github.com/crim-ca/stac-app/tree/master)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+# Changed
+
+- n/a
+
+# Fixed
+
+- Fix breaking PG connection setting when using ``stac-fastapi>=6``.
 
 [1.1.0](https://github.com/crim-ca/stac-app/tree/1.1.0)
 ------------------------------------------------------------------------------------------------------------------

--- a/src/stac_app.py
+++ b/src/stac_app.py
@@ -4,12 +4,14 @@
 import logging
 import os
 import time
+from packaging.version import Version
 from typing import Optional, Type, cast
 
 import asyncpg
 from buildpg import render
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import ORJSONResponse
+from stac_fastapi.api.version import __version__ as stac_fastapi_version
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.models import (
     ItemCollectionUri,
@@ -112,9 +114,15 @@ async def _load_script(script_basename: str, conn: asyncpg.Connection) -> None:
 async def startup_event() -> None:
     """Connect to database on startup and load custom functions."""
     max_retries = 60
+
+    # forward-compatibility setting
+    connect_to_db_kwargs = {}
+    if Version(stac_fastapi_version) >= Version("6.0"):
+        connect_to_db_kwargs["add_write_connection_pool"] = True
+
     for retry in range(max_retries):
         try:
-            await connect_to_db(app)
+            await connect_to_db(app, **connect_to_db_kwargs)
             break
         except Exception as err:
             logger.warning(


### PR DESCRIPTION
Not enforcing `stac-fastapi>=6` for the moment because of potential other changes that could break, but make it transparent for the time being whether v5 or v6 is used.