### PR TITLE
Patch requirement and test STAC App in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,6 @@ on:
   pull_request: {}
 
 env:
-  REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -23,11 +22,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      # make it available for the test job
-      - name: Save Docker image as tarball
-        run: docker save -o stac-app-image.tar ${{ steps.meta.outputs.tags }}
+          images: ${{ env.IMAGE_NAME }}
 
       - name: Build Docker Image
         id: push
@@ -36,6 +31,10 @@ jobs:
           context: .
           push: false
           tags: ${{ steps.meta.outputs.tags }}
+
+      # make it available for the test job
+      - name: Save Docker image as tarball
+        run: docker save -o stac-app-image.tar ${{ steps.meta.outputs.tags }}
 
     outputs:
       stac-app-docker-tag: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,66 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-docker:
+    name: Build STAC App Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build Docker Image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+
+    outputs:
+      stac-app-docker-tag: ${{ steps.meta.outputs.tags }}
+
+  test-docker:
+    name: Test STAC App
+    needs: [build-docker]
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        env:
+          POSTGRES_PASSWORD: postgres
+        image: ghcr.io/stac-utils/pgstac:v0.9.8
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    container:
+      image: ${{ needs.build-docker.outputs.stac-app-docker-tag }}
+      env:
+        PGPASSWORD: postgres
+        PGHOST: postgres
+        PGDATABASE: postgres
+        PGUSER: postgres
+
+    steps:
+      - name: Run Test
+        run: |
+          curl -f http://localhost:8000/stac | grep '"type":"Catalog","id":"stac-fastapi"'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,5 +63,5 @@ jobs:
             --retry-delay 5 \
             --retry-max-time 30 \
             --retry-connrefused \
-            "http://0.0.0.0:8000/stac/" \
+            "http://localhost:8000/stac/" \
             | grep '"type":"Catalog","id":"stac-fastapi"'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
   pull_request: {}
 
 env:
+  REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -22,7 +23,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       # make it available for the test job
       - name: Save Docker image as tarball

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,11 @@ jobs:
             -e PGHOST=postgres \
             -e PGDATABASE=postgres \
             -e PGUSER=postgres \
+            -e POSTGRES_DBNAME=postgis \
+            -e POSTGRES_HOST_READER=postgres \
+            -e POSTGRES_HOST_WRITER=postgres \
+            -e POSTGRES_PORT=5432 \
+            -e ROUTER_PREFIX=/stac \
             --name stac-app \
             ${{ needs.build-docker.outputs.stac-app-docker-tag }}
           curl \
@@ -85,5 +90,5 @@ jobs:
             --retry-delay 5 \
             --retry-max-time 30 \
             --retry-connrefused \
-            http://localhost:8000/stac \
+            "http://0.0.0.0:8000/stac/" \
             | grep '"type":"Catalog","id":"stac-fastapi"'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,6 @@ on:
   pull_request: {}
 
 env:
-  REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -23,7 +22,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAME }}
+
+      # make it available for the test job
+      - name: Save Docker image as tarball
+        run: docker save -o stac-app-image.tar ${{ steps.meta.outputs.tags }}
 
       - name: Build Docker Image
         id: push
@@ -52,15 +55,29 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-    container:
-      image: ${{ needs.build-docker.outputs.stac-app-docker-tag }}
-      env:
-        PGPASSWORD: postgres
-        PGHOST: postgres
-        PGDATABASE: postgres
-        PGUSER: postgres
-
     steps:
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: stac-app-image
+
+      - name: Load Docker image
+        run: docker load -i stac-app-image.tar
+
       - name: Run Test
         run: |
-          curl -f http://localhost:8000/stac | grep '"type":"Catalog","id":"stac-fastapi"'
+          docker run --rm -d \
+            --network host \
+            -e PGPASSWORD=postgres \
+            -e PGHOST=postgres \
+            -e PGDATABASE=postgres \
+            -e PGUSER=postgres \
+            --name stac-app \
+            ${{ needs.build-docker.outputs.stac-app-docker-tag }}
+          curl \
+            --retry 3 \
+            --retry-delay 5 \
+            --retry-max-time 30 \
+            --retry-connrefused \
+            http://localhost:8000/stac \
+            | grep '"type":"Catalog","id":"stac-fastapi"'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,19 @@ env:
 
 jobs:
   build-docker:
-    name: Build STAC App Docker Image
+    name: Test STAC App Docker Image
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        env:
+          POSTGRES_PASSWORD: postgres
+        image: ghcr.io/stac-utils/pgstac:v0.9.8
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Checkout
@@ -32,44 +43,6 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
 
-      # make it available for the test job
-      - name: Save Docker image as tarball
-        run: docker save -o stac-app-image.tar ${{ steps.meta.outputs.tags }}
-
-      - name: Upload image artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: stac-app-image
-          path: stac-app-image.tar
-
-    outputs:
-      stac-app-docker-tag: ${{ steps.meta.outputs.tags }}
-
-  test-docker:
-    name: Test STAC App
-    needs: [build-docker]
-    runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        env:
-          POSTGRES_PASSWORD: postgres
-        image: ghcr.io/stac-utils/pgstac:v0.9.8
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-    steps:
-      - name: Download image artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: stac-app-image
-
-      - name: Load Docker image
-        run: docker load -i stac-app-image.tar
-
       - name: Run Test
         run: |
           docker run --rm -d \
@@ -84,7 +57,7 @@ jobs:
             -e POSTGRES_PORT=5432 \
             -e ROUTER_PREFIX=/stac \
             --name stac-app \
-            ${{ needs.build-docker.outputs.stac-app-docker-tag }}
+            ${{ steps.meta.outputs.tags }}
           curl \
             --retry 3 \
             --retry-delay 5 \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,5 +73,5 @@ jobs:
               --retry-delay 5 \
               --retry-max-time 30 \
               --retry-connrefused \
-              "http://localhost:8000/stac/" \
+              "http://stac-app:8000/stac/" \
               | grep '"type":"Catalog","id":"stac-fastapi"'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,12 @@ jobs:
     services:
       postgres:
         env:
+          POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgis
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGDATABASE: postgis
         image: ghcr.io/stac-utils/pgstac:v0.9.8
         options: >-
           --health-cmd pg_isready
@@ -46,7 +51,8 @@ jobs:
       - name: Run Test
         run: |
           docker run --rm -d \
-            --network host \
+            --network ${{ job.container.network }} \
+            -p 8000:8000 \
             -e PGPASSWORD=postgres \
             -e PGHOST=postgres \
             -e PGDATABASE=postgres \
@@ -58,6 +64,7 @@ jobs:
             -e ROUTER_PREFIX=/stac \
             --name stac-app \
             ${{ steps.meta.outputs.tags }}
+          docker ps
           curl \
             --retry 3 \
             --retry-delay 5 \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,10 +65,13 @@ jobs:
             --name stac-app \
             ${{ steps.meta.outputs.tags }}
           docker ps
-          curl \
-            --retry 3 \
-            --retry-delay 5 \
-            --retry-max-time 30 \
-            --retry-connrefused \
-            "http://localhost:8000/stac/" \
-            | grep '"type":"Catalog","id":"stac-fastapi"'
+          docker run --rm \
+            --network ${{ job.container.network }} \
+            curlimages/curl:8.7.1 \
+            curl \
+              --retry 3 \
+              --retry-delay 5 \
+              --retry-max-time 30 \
+              --retry-connrefused \
+              "http://localhost:8000/stac/" \
+              | grep '"type":"Catalog","id":"stac-fastapi"'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,13 +20,13 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
 
       - name: Build Docker Image
         id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false
@@ -35,6 +35,12 @@ jobs:
       # make it available for the test job
       - name: Save Docker image as tarball
         run: docker save -o stac-app-image.tar ${{ steps.meta.outputs.tags }}
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: stac-app-image
+          path: stac-app-image.tar
 
     outputs:
       stac-app-docker-tag: ${{ steps.meta.outputs.tags }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,10 @@
 [Unreleased](https://github.com/crim-ca/stac-app/tree/master)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+- Fix missing `packaging` dependency.
+- Add a CI test building the Docker and doing a `curl` request on the landing page to ensure the API definition
+  can at the very least start without error. A DB connection is also used to validate that PostgreSQL is reachable
+  from the API service container using basic configurations.
 
 [2.0.0](https://github.com/crim-ca/stac-app/tree/2.0.0)
 ------------------------------------------------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+packaging==25.0
 stac-fastapi.api==6.0.0
 stac-fastapi.pgstac[validation]==6.0.0
 uvicorn==0.35.0


### PR DESCRIPTION
- Fix missing `packaging` dependency.
- Add a CI test building the Docker and doing a `curl` request on the landing page to ensure the API definition
  can at the very least start without error. A DB connection is also used to validate that PostgreSQL is reachable
  from the API service container using basic configurations.