### PR TITLE
Fix rel items links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 ------------------------------------------------------------------------------------------------------------------
 
 - Refactor repository to employ `pyproject.toml`, `bump-my-version` and `Makefile` DevOps utilities.
+- Fix `rel: items` links causing many duplicate and invalid references in responses if the submitted STAC Collections
+  or Items contained such references at creation. These links are now ignored given their special significance
+  (relates to [stac-utils/stac-fastapi-pgstac#294](https://github.com/stac-utils/stac-fastapi-pgstac/pull/294),
+  [stac-utils/stac-fastapi-pgstac#285](https://github.com/stac-utils/stac-fastapi-pgstac/issues/285) and
+  [crim-ca/stac-populator#109](https://github.com/crim-ca/stac-populator/issues/109)).
 
 [2.0.1](https://github.com/crim-ca/stac-app/tree/2.0.1)
 ------------------------------------------------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ LABEL version="2.0.1"
 COPY LICENSE ./
 COPY ./pyproject.toml pyproject.toml
 
-RUN apt update --no-install-recommends && apt-get install -y git  # FIXME: remove once patch released
 RUN pip install . && rm pyproject.toml
 
 COPY ./src/ /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ LABEL version="2.0.1"
 COPY LICENSE ./
 COPY ./pyproject.toml pyproject.toml
 
+RUN apt update --no-install-recommends && apt-get install -y git  # FIXME: remove once patch released
 RUN pip install . && rm pyproject.toml
 
 COPY ./src/ /app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
   "packaging==25.0",
   "stac-fastapi.api==6.0.0",
-  "stac-fastapi.pgstac[validation] @ git+https://github.com/crim-ca/stac-fastapi-pgstac@fix-link-rel-items",  # ==6.0.0+patch
+  "stac-fastapi.pgstac[validation]==6.0.1",
   "uvicorn==0.35.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
   "packaging==25.0",
   "stac-fastapi.api==6.0.0",
-  "stac-fastapi.pgstac[validation]==6.0.0",
+  "stac-fastapi.pgstac[validation] @ git+https://github.com/crim-ca/stac-fastapi-pgstac@fix-link-rel-items",  # ==6.0.0+patch
   "uvicorn==0.35.0",
 ]
 


### PR DESCRIPTION
## Detail

Marked as 'draft' as proof of concept. Will apply the relevant version once `stac-fastapi-pgstac` fix release is available.

## Referencs

- relates to https://github.com/stac-utils/stac-fastapi-pgstac/pull/294
- relates to https://github.com/stac-utils/stac-fastapi-pgstac/issues/285
- fixes https://github.com/crim-ca/stac-populator/issues/109 (filter content regardless of submitted value)

## Test

image `ghcr.io/crim-ca/stac-app:2.0.2-dev0` (see https://hirondelle.crim.ca/services/stac)

response is properly filtered to contain only the single valid `rel:items` entry on https://hirondelle.crim.ca/stac/collections/
