### PR TITLE
replace collection search token paging by offset paging until supported

### DIFF
--- a/src/stac_app.py
+++ b/src/stac_app.py
@@ -35,7 +35,7 @@ from stac_fastapi.extensions.core.free_text import FreeTextAdvancedExtension, Fr
 from stac_fastapi.extensions.core.pagination import (
     OffsetPaginationExtension,
     PaginationExtension,
-    TokenPaginationExtension
+    TokenPaginationExtension,
 )
 from stac_fastapi.extensions.core.query import QueryConformanceClasses
 from stac_fastapi.extensions.core.sort import SortConformanceClasses

--- a/src/stac_app.py
+++ b/src/stac_app.py
@@ -25,15 +25,18 @@ from stac_fastapi.extensions.core import (
     FieldsExtension,
     FilterExtension,
     ItemCollectionFilterExtension,
-    PaginationExtension,
     QueryExtension,
     SortExtension,
-    TokenPaginationExtension,
     TransactionExtension,
 )
 from stac_fastapi.extensions.core.collection_search import CollectionSearchExtension
 from stac_fastapi.extensions.core.fields import FieldsConformanceClasses
 from stac_fastapi.extensions.core.free_text import FreeTextAdvancedExtension, FreeTextConformanceClasses
+from stac_fastapi.extensions.core.pagination import (
+    OffsetPaginationExtension,
+    PaginationExtension,
+    TokenPaginationExtension
+)
 from stac_fastapi.extensions.core.query import QueryConformanceClasses
 from stac_fastapi.extensions.core.sort import SortConformanceClasses
 from stac_fastapi.pgstac.config import Settings
@@ -126,7 +129,10 @@ collection_base_extensions = [
             FreeTextConformanceClasses.COLLECTIONS_ADVANCED,
         ]
     ),
-    TokenPaginationExtension(),
+    # FIXME: token not supported for collections search (https://github.com/stac-utils/stac-fastapi-pgstac/issues/334)
+    #        if/once resolved, offer the choice using a convenience setting/env-var
+    # TokenPaginationExtension(),
+    OffsetPaginationExtension(),
 ]
 # NOTE:
 #   Using only the 'GET /collections' for search, since 'POST /collections' search
@@ -161,6 +167,9 @@ items_extensions = [
         ]
     ),
     ItemCollectionFilterExtension(client=FiltersClient()),
+    # FIXME: offset not supported for item search (https://github.com/stac-utils/stac-fastapi-pgstac/issues/334)
+    #        if/once resolved, offer the choice using a convenience setting/env-var
+    # OffsetPaginationExtension(),
     TokenPaginationExtension(),
 ]
 items_get_request_model = cast(
@@ -192,7 +201,7 @@ api = StacApi(
         os.getenv("STAC_FASTAPI_DESCRIPTION")
         or "Searchable spatiotemporal metadata describing climate and Earth observation datasets."
     ),
-    router=APIRouter(prefix=router_prefix),
+    router=APIRouter(prefix=router_prefix_str),
 )
 app = api.app
 


### PR DESCRIPTION
## Description

When `/collections` is requested with `?limit=` (or omitted with default 10 per page), and that the amount of collections is higher than the page limit, the paged response assumes `?offset=` parameter in the `next` link. If the application was configured with `token` paging (as currently), the `offset` parameters is not parsed properly by subsequent paging requests. 

This problem leads, for example, to STAC browser listing the first 10 collections as duplicates, N-times the amount of pages. For example, if the API contains 11 collections (2 pages of 10 and 1 respectively), the browser will display 20 collections (each one of the first page repeated), and never show the 1 from the following page. 

## Fixes

- fix collection search paging not working with `token` (using `offset` instead for now)
  (relates to https://github.com/stac-utils/stac-fastapi-pgstac/issues/334)
- fix bug when `ROUTER_PREFIX` is undefined (`None + ""` append error)

## Example

#### First Page 

<img width="752" height="480" alt="{55D7C4DE-D002-47DF-9B64-53B74384933C}" src="https://github.com/user-attachments/assets/7f8623fd-29bf-41a6-a4b6-b8036f084b04" />



#### Next Page - Before (repeated `montreal_2023`)

<img width="752" height="369" alt="{22B473E1-5876-41C3-8FE5-DB866D0D0073}" src="https://github.com/user-attachments/assets/c2bd2c56-8935-4924-92d8-c803bfed2c69" />


#### Next Page - After (expected `netyork_2024`)
<img width="752" alt="image" src="https://github.com/user-attachments/assets/2a4cf1e8-f353-415e-856d-faaf38e39289" />




