### PR TITLE
Update Python base image version in Dockerfile + Fix stac-fastapi dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,21 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v7.3.0
         with:
           context: .
           push: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,17 +32,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6.2.0
         with:
           images: ${{ env.IMAGE_NAME }}
 
       - name: Build Docker Image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.3.0
         with:
           context: .
           push: false
@@ -50,28 +50,9 @@ jobs:
 
       - name: Run Test
         run: |
-          docker run --rm -d \
-            --network ${{ job.container.network }} \
-            -p 8000:8000 \
-            -e PGPASSWORD=postgres \
-            -e PGHOST=postgres \
-            -e PGDATABASE=postgres \
-            -e PGUSER=postgres \
-            -e POSTGRES_DBNAME=postgis \
-            -e POSTGRES_HOST_READER=postgres \
-            -e POSTGRES_HOST_WRITER=postgres \
-            -e POSTGRES_PORT=5432 \
-            -e ROUTER_PREFIX=/stac \
-            --name stac-app \
-            ${{ steps.meta.outputs.tags }}
+          make docker-run \
+            DOCKER_RUN_IMAGE="${{ steps.meta.outputs.tags }}" \
+            DOCKER_RUN_NETWORK="${{ job.container.network }}"
           docker ps
-          docker run --rm \
-            --network ${{ job.container.network }} \
-            curlimages/curl:8.7.1 \
-            curl \
-              --retry 3 \
-              --retry-delay 5 \
-              --retry-max-time 30 \
-              --retry-connrefused \
-              "http://stac-app:8000/stac/" \
-              | grep '"type":"Catalog","id":"stac-fastapi"'
+          make docker-test \
+            DOCKER_TEST_NETWORK="${{ job.container.network }}"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 ------------------------------------------------------------------------------------------------------------------
 
 - Update Docker with Python 3.13.14 for security fixes.
+- Update `stac-fastapi.api` to 6.3.2 and `stac-fastapi.pgstac` to 6.3.1 with extension move away from `core` module.
 
 [2.3.1](https://github.com/crim-ca/stac-app/tree/2.3.1) (2026-04-16)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 
 - Update Docker with Python 3.13.14 for security fixes.
 - Update `stac-fastapi.api` to 6.3.2 and `stac-fastapi.pgstac` to 6.3.1 with extension move away from `core` module.
+- Update `Makefile` to provide similar operations employed within the CI to setup and test the API.
 
 [2.3.1](https://github.com/crim-ca/stac-app/tree/2.3.1) (2026-04-16)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 [Unreleased](https://github.com/crim-ca/stac-app/tree/main) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-<!-- insert list items of new changes here -->
+- Update Docker with Python 3.13.14 for security fixes.
 
 [2.3.1](https://github.com/crim-ca/stac-app/tree/2.3.1) (2026-04-16)
 ------------------------------------------------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.11-slim
+FROM python:3.13.14-slim
 LABEL description.short="STAC Populator"
 LABEL description.long="CRIM implementation of FastAPI application for SpatioTemporal Asset Catalogs (STAC) for bird-house platform."
 LABEL maintainer="Francis Charette-Migneault <francis.charette-migneault@crim.ca>"

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,67 @@ APP_ROOT    := $(abspath $(lastword $(MAKEFILE_NAME))/..)
 APP_NAME    := stac-app
 APP_VERSION ?= 2.3.1
 
-DOCKER_TAG := ghcr.io/crim-ca/stac-app:$(APP_VERSION)
+DOCKER_TAG := ghcr.io/crim-ca/$(APP_NAME):$(APP_VERSION)
 DOCKER_XARGS ?=
+DOCKER_NETWORK ?= stac-network
+DOCKER_DB_NAME ?= postgres
+DOCKER_DB_IMAGE ?= ghcr.io/stac-utils/pgstac:v0.9.8
+DOCKER_RUN_IMAGE ?= $(DOCKER_TAG)
+DOCKER_TEST_IMAGE ?= curlimages/curl:8.21.0
 
 docker-build:
 	docker build "$(APP_ROOT)" -f "$(APP_ROOT)/Dockerfile" -t "$(DOCKER_TAG)" $(DOCKER_XARGS)
+
+docker-network:
+	docker network create $(DOCKER_NETWORK) || true
+
+docker-pg: docker-network
+	docker ps | grep $(DOCKER_DB_NAME) || \
+	docker run --rm -d \
+		--network $(DOCKER_NETWORK) \
+		-e POSTGRES_PASSWORD=postgres \
+		-e POSTGRES_USER=postgres \
+		-e POSTGRES_DB=postgis \
+		-e PGDATABASE=postgis \
+		-e PGUSER=postgres \
+		-e PGPASSWORD=postgres \
+		--name $(DOCKER_DB_NAME) \
+		$(DOCKER_DB_IMAGE)
+
+docker-run: docker-network docker-pg
+	docker run --rm -d \
+		--network $(DOCKER_NETWORK) \
+		-p 8000:8000 \
+		-e POSTGRES_DBNAME=postgis \
+		-e POSTGRES_PASSWORD=postgres \
+		-e POSTGRES_USER=postgres \
+		-e POSTGRES_DB=postgis \
+		-e PGDATABASE=postgis \
+		-e PGUSER=postgres \
+		-e PGPASSWORD=postgres \
+		-e PGHOST=$(DOCKER_DB_NAME) \
+		-e POSTGRES_HOST_READER=$(DOCKER_DB_NAME) \
+		-e POSTGRES_HOST_WRITER=$(DOCKER_DB_NAME) \
+		-e POSTGRES_PORT=5432 \
+		-e ROUTER_PREFIX=/stac \
+		--name $(APP_NAME) \
+		$(DOCKER_RUN_IMAGE)
+
+docker-test: docker-network
+	docker run --rm \
+		--network $(DOCKER_NETWORK) \
+		$(DOCKER_TEST_IMAGE) \
+		curl \
+			--retry 3 \
+			--retry-delay 5 \
+			--retry-max-time 30 \
+			--retry-connrefused \
+			"http://$(APP_NAME):8000/stac/" \
+			| grep '"type":"Catalog","id":"stac-fastapi"'
+
+docker-stop:
+	docker stop $(DOCKER_DB_NAME) || true
+	docker stop $(APP_NAME) || true
 
 install:
 	pip install "$(APP_ROOT)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
     "Topic :: Database :: Database Engines/Servers",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
@@ -44,10 +45,10 @@ classifiers = [
 requires-python = ">=3.10,<4"
 
 dependencies = [
-  "packaging==25.0",
-  "stac-fastapi.api==6.2.1",
-  "stac-fastapi.pgstac[validation]==6.0.1",
-  "uvicorn==0.35.0",
+  "packaging==26.2",
+  "stac-fastapi.api==6.3.2",
+  "stac-fastapi.pgstac[validation]==6.3.1",
+  "uvicorn==0.50.2",
 ]
 
 [project.urls]

--- a/src/stac_app.py
+++ b/src/stac_app.py
@@ -20,7 +20,7 @@ from stac_fastapi.api.models import (
     create_post_request_model,
 )
 from stac_fastapi.api.version import __version__ as stac_fastapi_version
-from stac_fastapi.extensions.core import (
+from stac_fastapi.extensions import (
     CollectionSearchFilterExtension,
     FieldsExtension,
     FilterExtension,
@@ -29,12 +29,12 @@ from stac_fastapi.extensions.core import (
     SortExtension,
     TransactionExtension,
 )
-from stac_fastapi.extensions.core.collection_search import CollectionSearchExtension
-from stac_fastapi.extensions.core.fields import FieldsConformanceClasses
-from stac_fastapi.extensions.core.free_text import FreeTextAdvancedExtension, FreeTextConformanceClasses
-from stac_fastapi.extensions.core.pagination import OffsetPaginationExtension, TokenPaginationExtension
-from stac_fastapi.extensions.core.query import QueryConformanceClasses
-from stac_fastapi.extensions.core.sort import SortConformanceClasses
+from stac_fastapi.extensions.collection_search import CollectionSearchExtension
+from stac_fastapi.extensions.fields import FieldsConformanceClasses
+from stac_fastapi.extensions.free_text import FreeTextAdvancedExtension, FreeTextConformanceClasses
+from stac_fastapi.extensions.pagination import OffsetPaginationExtension, TokenPaginationExtension
+from stac_fastapi.extensions.query import QueryConformanceClasses
+from stac_fastapi.extensions.sort import SortConformanceClasses
 from stac_fastapi.pgstac.config import Settings
 from stac_fastapi.pgstac.core import CoreCrudClient
 from stac_fastapi.pgstac.db import close_db_connection, connect_to_db


### PR DESCRIPTION
- Update Docker with Python 3.13.14 for security fixes.
- Update `stac-fastapi.api` to 6.3.2 and `stac-fastapi.pgstac` to 6.3.1 with extension move away from `core` module.
- Update `Makefile` to provide similar operations employed within the CI to setup and test the API.